### PR TITLE
Add basic unit tests for bot utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+    - name: Install apt packages
+      run: sudo apt-get update && sudo apt-get install -y $(cat apt.txt)
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run tests
+      run: pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements.txt pytest
     - name: Run tests
       run: pytest -q

--- a/tests/test_music_queue.py
+++ b/tests/test_music_queue.py
@@ -1,0 +1,56 @@
+import pytest
+from music_queue import MusicQueue
+
+class DummySong:
+    def __init__(self, title):
+        self.title = title
+
+def test_queue_add_and_get_next():
+    q = MusicQueue()
+    s1 = DummySong("song1")
+    s2 = DummySong("song2")
+    q.add(s1)
+    q.add(s2)
+    assert q.size == 2
+    assert not q.is_empty
+    first = q.get_next()
+    assert first is s1
+    assert q.current is s1
+    assert q.size == 1
+    second = q.get_next()
+    assert second is s2
+    assert q.current is s2
+    assert q.size == 0
+
+
+def test_queue_loop_mode():
+    q = MusicQueue()
+    s1 = DummySong("song1")
+    q.add(s1)
+    q.get_next()
+    q.loop_mode = True
+    assert q.get_next() is s1
+
+
+def test_queue_skip_and_clear():
+    q = MusicQueue()
+    s1 = DummySong("s1")
+    s2 = DummySong("s2")
+    q.add(s1)
+    q.add(s2)
+    q.get_next()  # play first
+    skipped = q.skip()
+    assert skipped is s2
+    assert q.current is s2
+    assert q.size == 0
+    q.clear()
+    assert q.is_empty
+
+
+def test_queue_shuffle():
+    q = MusicQueue()
+    songs = [DummySong(str(i)) for i in range(5)]
+    for song in songs:
+        q.add(song)
+    q.shuffle()
+    assert set(s.title for s in q.queue) == set(str(i) for i in range(5))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,50 @@
+import discord
+from utils import format_duration, create_queue_embed, create_song_embed
+
+class DummySong:
+    def __init__(self, title, duration=60, uploader="test", thumbnail=None):
+        self.title = title
+        self.duration = duration
+        self.uploader = uploader
+        self.thumbnail = thumbnail
+
+    def format_duration(self):
+        return format_duration(self.duration)
+
+class DummyQueue:
+    def __init__(self):
+        self.current = None
+        self.queue = []
+        self.loop_mode = False
+
+
+def test_format_duration():
+    assert format_duration(0) == "Unknown"
+    assert format_duration(65) == "1:05"
+
+
+def test_create_queue_embed_empty():
+    q = DummyQueue()
+    embed = create_queue_embed(q)
+    assert embed.title == "🎵 Music Queue"
+    assert embed.fields[0].name == "📝 Queue"
+
+
+def test_create_queue_embed_with_songs():
+    q = DummyQueue()
+    q.current = DummySong("current")
+    q.queue.append(DummySong("next"))
+    q.loop_mode = True
+    embed = create_queue_embed(q)
+    field_names = [f.name for f in embed.fields]
+    assert "🎵 Now Playing" in field_names
+    assert "🔂 Loop Mode" in field_names
+    assert any(name.startswith("📝 Up Next") for name in field_names)
+
+
+def test_create_song_embed():
+    song = DummySong("song", duration=70, uploader="me", thumbnail="http://x")
+    embed = create_song_embed(song, title="Info")
+    assert embed.title == "Info"
+    assert embed.fields[0].name == "Duration"
+    assert embed.fields[1].name == "Uploader"

--- a/tests/test_youtube_helper.py
+++ b/tests/test_youtube_helper.py
@@ -1,0 +1,33 @@
+from alternative_extractor import AlternativeExtractor
+from youtube_helper import get_troubleshooting_tips
+from web_server import update_bot_status, bot_status
+from ffmpeg_utils import ffmpeg_manager
+
+
+def test_extract_video_id():
+    url_variants = [
+        "https://www.youtube.com/watch?v=abc123",
+        "https://youtu.be/abc123",
+        "https://www.youtube.com/embed/abc123",
+        "https://www.youtube.com/v/abc123",
+    ]
+    for url in url_variants:
+        assert AlternativeExtractor._extract_video_id(url) == "abc123"
+    assert AlternativeExtractor._extract_video_id("https://example.com") is None
+
+
+def test_get_troubleshooting_tips():
+    tips = get_troubleshooting_tips()
+    assert any("voice channel" in t for t in tips)
+
+
+def test_update_bot_status():
+    update_bot_status(connected=True, guilds=2)
+    assert bot_status["connected"] is True
+    assert bot_status["guilds"] == 2
+
+
+def test_ffmpeg_options():
+    opts = ffmpeg_manager.get_optimal_ffmpeg_options()
+    assert "pcm" in opts and "opus" in opts
+    assert "before_options" in opts["pcm"]


### PR DESCRIPTION
## Summary
- add unit tests for music queue functionality
- add tests for embed utilities and formatting helpers
- add tests for web utilities and YouTube helper functions
- add CI workflow to run tests automatically on push or PR

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688372c76a148326931de5f401c7f109